### PR TITLE
Support static link and static CRT

### DIFF
--- a/msvc10/Makefile
+++ b/msvc10/Makefile
@@ -1,5 +1,15 @@
+# USAGE:
+#
 #  Build debug version:		nmake
 #  Build release version:	nmake nodebug=1
+#
+#  Build without MSVCRT: 	nmake nomsvcrt=1
+#  Build release version without MSVCRT:
+#  				nmake nodebug=1 nomsvcrt=1
+#
+#  Build static link library:	nmake static_libiconv=1
+#  Build release version of static link library without MSVCRT:
+#  				nmake nodebug=1 nomsvcrt=1 static_libiconv=1
 
 OUTPUTS =	iconv.lib iconv_no_i18n.exe
 
@@ -19,16 +29,6 @@ INCLUDES =	-I. -I..\srclib
 
 CCFLAGS =	/wd 4100 /wd 4819 /wd 4127 $(INCLUDES) $(DEFINES)
 
-!ifdef STATIC_LIBICONV
-CCFLAGS =	$(CCFLAGS) /DSTATIC_LIBICONV
-!endif
-
-!ifdef USE_STATIC_CRT
-CVARS =		$(cvarsmt)
-!else
-CVARS =		$(cvarsdll)
-!endif
-
 ############################################################################
 # WINDOWS BUILD SETTINGS.
 
@@ -37,6 +37,20 @@ TARGET = WINNT
 TARGETLANG = LANG_JAPANESE
 
 !INCLUDE <Win32.Mak>
+
+!IFDEF STATIC_LIBICONV
+CCFLAGS = $(CCFLAGS) /DSTATIC_LIBICONV
+!ENDIF
+
+!IFDEF NOMSVCRT
+_CVARS = $(cvarsmt)
+_LIBS_EXE = $(guilibsmt)
+_LIBS_DLL = $(conlibsmt)
+!ELSE
+_CVARS = $(cvarsdll)
+_LIBS_EXE = $(guilibsdll)
+_LIBS_DLL = $(conlibsdll)
+!ENDIF
 
 build : $(OUTPUTS)
 
@@ -65,29 +79,29 @@ distclean : clean
 
 OBJS_LIBICONV_DLL = lib_iconv.obj relocatable.obj localcharset.obj
 
-!ifdef STATIC_LIBICONV
+!IFDEF STATIC_LIBICONV
 iconv.lib : $(OBJS_LIBICONV_DLL)
 	LIB /NOLOGO /OUT:$@ $(OBJS_LIBICONV_DLL)
-!else
+!ELSE
 iconv.lib : iconv.dll
 
 iconv.dll : $(OBJS_LIBICONV_DLL)
-	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(dlllflags) $(_LIBS_DLL) $(LFLAGS) \
 		/OUT:$@ $(OBJS_LIBICONV_DLL)
-!endif
+!ENDIF
 
 lib_iconv.obj : ..\lib\iconv.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		$(DEFINES_LIBICONV) \
 		/Fo$@ /c ..\lib\iconv.c
 
 relocatable.obj : ..\lib\relocatable.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		$(DEFINES_LIBICONV) \
 		/Fo$@ /c ..\lib\relocatable.c
 
 localcharset.obj : ..\libcharset\lib\localcharset.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		$(DEFINES_LIBICONV) \
 		/Fo$@ /c ..\libcharset\lib\localcharset.c
 
@@ -96,93 +110,93 @@ localcharset.obj : ..\libcharset\lib\localcharset.c
 OBJS_ICONV_NO_I18N_EXE = iconv_no_i18n.obj progname.obj width.obj safe-read.obj
 
 iconv_no_i18n.exe : $(OBJS_ICONV_NO_I18N_EXE) iconv.lib
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ $(OBJS_ICONV_NO_I18N_EXE) iconv.lib
 
 iconv_no_i18n.obj : ..\src\iconv_no_i18n.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\src\iconv_no_i18n.c
 
 progname.obj : ..\srclib\progname.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\srclib\progname.c
 
 width.obj : ..\srclib\uniwidth\width.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\srclib\uniwidth\width.c
 
 safe-read.obj : ..\srclib\safe-read.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\srclib\safe-read.c
 
 ### table-from.exe
 
 table-from.exe : table-from.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ table-from.obj iconv.lib
 
 table-from.obj : ..\tests\table-from.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\table-from.c
 
 ### table-to.exe
 
 table-to.exe : table-to.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ table-to.obj iconv.lib
 
 table-to.obj : ..\tests\table-to.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\table-to.c
 
 ### test-shiftseq.exe
 
 test-shiftseq.exe : test-shiftseq.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ test-shiftseq.obj iconv.lib
 
 test-shiftseq.obj : ..\tests\test-shiftseq.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\test-shiftseq.c
 
 ### test-to-wchar.exe
 
 test-to-wchar.exe : test-to-wchar.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ test-to-wchar.obj iconv.lib
 
 test-to-wchar.obj : ..\tests\test-to-wchar.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\test-to-wchar.c
 
 ### genutf8.exe
 
 genutf8.exe : genutf8.obj
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ genutf8.obj
 
 genutf8.obj : ..\tests\genutf8.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\genutf8.c
 
 ### gengb18030z.exe
 
 gengb18030z.exe : gengb18030z.obj
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ gengb18030z.obj
 
 gengb18030z.obj : ..\tests\gengb18030z.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\gengb18030z.c
 
 ### uniq-u.exe
 
 uniq-u.exe : uniq-u.obj
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(_LIBS_EXE) $(LFLAGS) \
 		/OUT:$@ uniq-u.obj
 
 uniq-u.obj : ..\tests\uniq-u.c
-	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(_CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\uniq-u.c
 
 ############################################################################

--- a/msvc10/Makefile
+++ b/msvc10/Makefile
@@ -1,7 +1,7 @@
 #  Build debug version:		nmake
 #  Build release version:	nmake nodebug=1
 
-OUTPUTS =	iconv.dll iconv_no_i18n.exe
+OUTPUTS =	iconv.lib iconv_no_i18n.exe
 
 DEFINES =	/D_BIND_TO_CURRENT_VCLIBS_VERSION=1 \
 		/D_CRT_SECURE_NO_WARNINGS=1
@@ -18,6 +18,10 @@ DEFINES_LIBICONV = \
 INCLUDES =	-I. -I..\srclib
 
 CCFLAGS =	/wd 4100 /wd 4819 /wd 4127 $(INCLUDES) $(DEFINES)
+
+!ifdef STATIC_LIBICONV
+CCFLAGS =	$(CCFLAGS) /DSTATIC_LIBICONV
+!endif
 
 ############################################################################
 # WINDOWS BUILD SETTINGS.
@@ -55,9 +59,16 @@ distclean : clean
 
 OBJS_LIBICONV_DLL = lib_iconv.obj relocatable.obj localcharset.obj
 
+!ifdef STATIC_LIBICONV
+iconv.lib : $(OBJS_LIBICONV_DLL)
+	LIB /NOLOGO /OUT:$@ $(OBJS_LIBICONV_DLL)
+!else
+iconv.lib : iconv.dll
+
 iconv.dll : $(OBJS_LIBICONV_DLL)
 	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibsdll) $(LFLAGS) \
 		/OUT:$@ $(OBJS_LIBICONV_DLL)
+!endif
 
 lib_iconv.obj : ..\lib\iconv.c
 	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
@@ -78,7 +89,7 @@ localcharset.obj : ..\libcharset\lib\localcharset.c
 
 OBJS_ICONV_NO_I18N_EXE = iconv_no_i18n.obj progname.obj width.obj safe-read.obj
 
-iconv_no_i18n.exe : $(OBJS_ICONV_NO_I18N_EXE) iconv.dll
+iconv_no_i18n.exe : $(OBJS_ICONV_NO_I18N_EXE) iconv.lib
 	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
 		/OUT:$@ $(OBJS_ICONV_NO_I18N_EXE) iconv.lib
 

--- a/msvc10/Makefile
+++ b/msvc10/Makefile
@@ -23,6 +23,12 @@ CCFLAGS =	/wd 4100 /wd 4819 /wd 4127 $(INCLUDES) $(DEFINES)
 CCFLAGS =	$(CCFLAGS) /DSTATIC_LIBICONV
 !endif
 
+!ifdef USE_STATIC_CRT
+CVARS =		$(cvarsmt)
+!else
+CVARS =		$(cvarsdll)
+!endif
+
 ############################################################################
 # WINDOWS BUILD SETTINGS.
 
@@ -66,22 +72,22 @@ iconv.lib : $(OBJS_LIBICONV_DLL)
 iconv.lib : iconv.dll
 
 iconv.dll : $(OBJS_LIBICONV_DLL)
-	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(dlllflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ $(OBJS_LIBICONV_DLL)
 !endif
 
 lib_iconv.obj : ..\lib\iconv.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		$(DEFINES_LIBICONV) \
 		/Fo$@ /c ..\lib\iconv.c
 
 relocatable.obj : ..\lib\relocatable.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		$(DEFINES_LIBICONV) \
 		/Fo$@ /c ..\lib\relocatable.c
 
 localcharset.obj : ..\libcharset\lib\localcharset.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		$(DEFINES_LIBICONV) \
 		/Fo$@ /c ..\libcharset\lib\localcharset.c
 
@@ -90,93 +96,93 @@ localcharset.obj : ..\libcharset\lib\localcharset.c
 OBJS_ICONV_NO_I18N_EXE = iconv_no_i18n.obj progname.obj width.obj safe-read.obj
 
 iconv_no_i18n.exe : $(OBJS_ICONV_NO_I18N_EXE) iconv.lib
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ $(OBJS_ICONV_NO_I18N_EXE) iconv.lib
 
 iconv_no_i18n.obj : ..\src\iconv_no_i18n.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\src\iconv_no_i18n.c
 
 progname.obj : ..\srclib\progname.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\srclib\progname.c
 
 width.obj : ..\srclib\uniwidth\width.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\srclib\uniwidth\width.c
 
 safe-read.obj : ..\srclib\safe-read.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\srclib\safe-read.c
 
 ### table-from.exe
 
 table-from.exe : table-from.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ table-from.obj iconv.lib
 
 table-from.obj : ..\tests\table-from.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\table-from.c
 
 ### table-to.exe
 
 table-to.exe : table-to.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ table-to.obj iconv.lib
 
 table-to.obj : ..\tests\table-to.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\table-to.c
 
 ### test-shiftseq.exe
 
 test-shiftseq.exe : test-shiftseq.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ test-shiftseq.obj iconv.lib
 
 test-shiftseq.obj : ..\tests\test-shiftseq.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\test-shiftseq.c
 
 ### test-to-wchar.exe
 
 test-to-wchar.exe : test-to-wchar.obj iconv.dll
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ test-to-wchar.obj iconv.lib
 
 test-to-wchar.obj : ..\tests\test-to-wchar.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\test-to-wchar.c
 
 ### genutf8.exe
 
 genutf8.exe : genutf8.obj
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ genutf8.obj
 
 genutf8.obj : ..\tests\genutf8.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\genutf8.c
 
 ### gengb18030z.exe
 
 gengb18030z.exe : gengb18030z.obj
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ gengb18030z.obj
 
 gengb18030z.obj : ..\tests\gengb18030z.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\gengb18030z.c
 
 ### uniq-u.exe
 
 uniq-u.exe : uniq-u.obj
-	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibsdll) $(LFLAGS) \
+	$(link) /NOLOGO $(ldebug) $(conlflags) $(conlibs) $(LFLAGS) \
 		/OUT:$@ uniq-u.obj
 
 uniq-u.obj : ..\tests\uniq-u.c
-	$(CC) $(cdebug) $(cflags) $(cvarsdll) $(CCFLAGS) \
+	$(CC) $(cdebug) $(cflags) $(CVARS) $(CCFLAGS) \
 		/Fo$@ /c ..\tests\uniq-u.c
 
 ############################################################################

--- a/msvc10/iconv.h
+++ b/msvc10/iconv.h
@@ -22,7 +22,9 @@
 #define _LIBICONV_H
 
 #define _LIBICONV_VERSION 0x010E    /* version number: (major<<8) + minor */
-#ifdef BUILDING_LIBICONV
+#ifdef STATIC_LIBICONV
+#define LIBICONV_DLL_EXPORTED
+#elif defined(BUILDING_LIBICONV)
 #define LIBICONV_DLL_EXPORTED __declspec(dllexport)
 #else
 #define LIBICONV_DLL_EXPORTED __declspec(dllimport)


### PR DESCRIPTION
Two options are added.

1. `STATIC_LIBICONV`: If defined static link library is built, otherwise DLL is built.
2. `NOMSVCRT`: If defined static CRT is linked, otherwise msvcrXX.dll is linked.